### PR TITLE
Fix leaves check to accept whitelisted leaf blocks that don't have distance property

### DIFF
--- a/src/main/kotlin/trees/GenericTree.kt
+++ b/src/main/kotlin/trees/GenericTree.kt
@@ -172,7 +172,7 @@ class GenericTree : TreeType {
 
 			val currentState = level.getBlockState(current)
 			val optionalDistanceAt = LeavesBlock.getOptionalDistanceAt(currentState)
-			if (node.distance != optionalDistanceAt.orElse(0)) {
+			if (optionalDistanceAt.isPresent() && node.distance != optionalDistanceAt.getAsInt()) {
 				continue
 			}
 			if (visited.contains(current) || node.distance > this.config.algorithm.maxLeavesRadius) {


### PR DESCRIPTION
Since 0.13 the leaf gathering loop uses `LeavesBlock.getOptionalDistanceAt` instead of `blockState.DISTANCE`. However, the new code doesn't allow leaves that don't have a distance value set. This seems unintended.

Back in the old 0.12.7 if a leaf didn't have a distance property, it was still checked against the whitelist. In the current code, if no distance is found, the leaf is rejected. This makes the whitelist somewhat useless because it's never queried. It also breaks all modded trees that do implement #minecraft:leaves but don't extend LeavesBlock.

As far as I can tell this is not intended.

This PR checks if a block has a LeavesBlock Distance property, and if not, it continues to the isLeafBlock check which queries the whitelist. This is similar to 0.12 which checked `blockState.hasProperty(LeavesBlock.DISTANCE)`